### PR TITLE
Update openml version

### DIFF
--- a/meta_automl/data_preparation/dataset/dataset_base.py
+++ b/meta_automl/data_preparation/dataset/dataset_base.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 from abc import abstractmethod, ABC
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Union, Optional, List, Any
+from typing import Optional, List, Any
 
-import numpy as np
 import pandas as pd
-import scipy as sp
 
 from meta_automl.data_preparation.file_system import CacheOperator, get_dataset_cache_path
 
@@ -16,8 +14,8 @@ DatasetIDType = Any
 
 @dataclass
 class DatasetData:
-    x: Union[np.ndarray, pd.DataFrame, sp.sparse.csr_matrix]
-    y: Optional[Union[np.ndarray, pd.DataFrame]] = None
+    x: pd.DataFrame
+    y: Optional[pd.DataFrame] = None
     categorical_indicator: Optional[List[bool]] = None
     attribute_names: Optional[List[str]] = None
 

--- a/meta_automl/data_preparation/dataset/openml_dataset.py
+++ b/meta_automl/data_preparation/dataset/openml_dataset.py
@@ -33,9 +33,8 @@ class OpenMLDataset(DatasetBase):
                                                      **get_dataset_kwargs)
         return cls(openml_dataset.id)
 
-    def get_data(self, dataset_format: str = 'dataframe') -> DatasetData:
+    def get_data(self) -> DatasetData:
         X, y, categorical_indicator, attribute_names = self._openml_dataset.get_data(
-            target=self._openml_dataset.default_target_attribute,
-            dataset_format=dataset_format
+            target=self._openml_dataset.default_target_attribute
         )
         return DatasetData(X, y, categorical_indicator, attribute_names)

--- a/meta_automl/data_preparation/meta_features_extractors/pymfe_extractor.py
+++ b/meta_automl/data_preparation/meta_features_extractors/pymfe_extractor.py
@@ -39,10 +39,10 @@ class PymfeExtractor(MetaFeaturesExtractor):
                     (mfs := self._get_meta_features_cache(dataset.id_, meta_feature_names))):
                 meta_features[dataset.id_] = mfs
             else:
-                loaded_dataset = dataset.get_data(dataset_format='array')
-                cat_cols = [i for i, val in enumerate(loaded_dataset.categorical_indicator) if val]
-                x = loaded_dataset.x
-                y = loaded_dataset.y
+                dataset_data = dataset.get_data()
+                cat_cols = [i for i, val in enumerate(dataset_data.categorical_indicator) if val]
+                x = dataset_data.x.to_numpy()
+                y = dataset_data.y.to_numpy()
                 if fill_input_nans:
                     x = self.fill_nans(x)
                 mfe = self._extractor.fit(x, y, cat_cols=cat_cols)

--- a/meta_automl/data_preparation/models_loaders/fedot_pipelines_loader.py
+++ b/meta_automl/data_preparation/models_loaders/fedot_pipelines_loader.py
@@ -31,7 +31,7 @@ def evaluate_classification_fedot_pipeline(pipeline, input_data):
 
 def get_n_best_fedot_performers(dataset: DatasetBase, pipelines: List[Pipeline], n_best: int = 1) -> List[Model]:
     data = dataset.get_data()
-    X, y_test = data.x, data.y
+    X, y_test = data.x.to_numpy(), data.y.to_numpy()
     input_data = InputData(idx=np.arange(0, len(X)), features=X, target=y_test, data_type=DataTypesEnum.table,
                            task=Task(TaskTypesEnum.classification))
     fitnesses = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fedot==0.7.1
 numpy==1.24.4
-openml==0.14.0
+openml==0.14.1
 pandas==2.0.3
 pymfe==0.4.2
 pytest==7.4.0


### PR DESCRIPTION
openml-python 14.0 stopped loading datasets' data with 503 error from server. The version 14.1 works fine. Presumably, the error was fixed with the update.

Closes #36 

Changelist:
- Moved openml from 14.0 to 14.1 in requirements.txt
- Removed deprecated argument "dataset_format", since it will be removed in 15.0. Also, eliminates the corresponding deprecation warning.
- Minor variable naming changes